### PR TITLE
Add Alpine main repo URL for resolving libssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Tim de Pater <code@trafex.nl>
 RUN apk --no-cache add php7 php7-fpm php7-mysqli php7-json php7-openssl php7-curl \
     php7-zlib php7-xml php7-phar php7-intl php7-dom php7-xmlreader php7-ctype \
     php7-mbstring php7-gd nginx supervisor curl bash \
+    --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
     --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
 
 # Configure nginx


### PR DESCRIPTION
Had to add main repository URL otherwise I was getting the following error when trying to build the image.

```
  so:libcrypto.so.38 (missing):
    required by:
                 php7-openssl-7.0.12-r0[so:libcrypto.so.38]
  so:libssl.so.39 (missing):
    required by:
                 php7-openssl-7.0.12-r0[so:libssl.so.39]
```