### PR TITLE
Updated WordPress to 4.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ WORKDIR /var/www/wp-content
 RUN chown -R nobody.nobody /var/www
 
 # WordPress
-ENV WORDPRESS_VERSION 4.8.2
-ENV WORDPRESS_SHA1 a99115b3b6d6d7a1eb6c5617d4e8e704ed50f450
+ENV WORDPRESS_VERSION 4.8.3
+ENV WORDPRESS_SHA1 8efc0b9f6146e143ed419b5419d7bb8400a696fc
 
 RUN mkdir -p /usr/src
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lightweight WordPress container with Nginx 1.12 & PHP-FPM 7.1 based on Alpine Linux.
 
-_WordPress version currently installed:_ **4.8.2**
+_WordPress version currently installed:_ **4.8.3**
 
 * Used in production for my own sites, making it stable, tested and up-to-date
 * Optimized for 100 concurrent users


### PR DESCRIPTION
### What has been done
- Updated WordPress to 4.8.3

### How to test
- Pull this branch
- Run docker-compose up --build
- See that the latest version of WordPress has been installed.

### Notes
Nice container!