### PR TITLE
Issue Resolved: Failed behind load balancers and reverse proxies that…

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -15,9 +15,8 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', dirname(__FILE__) . '/');
 }
 
-if ( (!empty( $_SERVER['HTTP_X_FORWARDED_HOST'])) ||
-	 (!empty( $_SERVER['HTTP_X_FORWARDED_FOR'])) ) {
-	$_SERVER['HTTPS'] = 'on';
+if ( (!empty( $_SERVER['HTTP_X_FORWARDED_PROTO'])) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+    $_SERVER['HTTPS'] = 'on';
 }
 
 require_once(ABSPATH . 'wp-secrets.php');

--- a/wp-config.php
+++ b/wp-config.php
@@ -15,5 +15,10 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', dirname(__FILE__) . '/');
 }
 
+if ( (!empty( $_SERVER['HTTP_X_FORWARDED_HOST'])) ||
+	 (!empty( $_SERVER['HTTP_X_FORWARDED_FOR'])) ) {
+	$_SERVER['HTTPS'] = 'on';
+}
+
 require_once(ABSPATH . 'wp-secrets.php');
 require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
**Symptoms**
HTTPS pages behind a load balancer or a reverse proxy (e.g. docker or nginx) fail to load, and wp-login.php creates an infinite redirect loop. 

**Cause**
is_ssl() returns false

**Solution**
Use the protocols (which should be) properly forward the requested protocol.  Added a check for the forwarded protocol and force the PHP Environment variable HTTPS to 'on'