### PR TITLE
Updated docker-compose.yml to version 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: '3.5'
+
 services:
   db:
     image: mariadb:10.3


### PR DESCRIPTION
### What has been done
- Updated the docker-compose yml file to version 3.5, which works as of Docker 2017.12.0

### How to test
- Pull this branch
- Run docker-compose up --build
- See that with a sufficiently recent docker-ce (2017.12.0 or higher), this works great!

### Notes
- I picked version 3.5 so we can have a Docker-CE that's almost a year old right now. I felt that this was a close enough cut-off point. Keep the spirit of moving forward alive!
- Migration was a breeze, as the complete file was forwards compatible.
