### PR TITLE
Support for beta builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /var/www/wp-content
 RUN chown -R nobody.nobody /var/www
 
 # WordPress
-ENV WORDPRESS_VERSION 4.9.8
-ENV WORDPRESS_SHA1 0945bab959cba127531dceb2c4fed81770812b4f
+ENV WORDPRESS_VERSION 5.0-beta2
+ENV WORDPRESS_SHA1 61ce4aa986dc31717d43549853503b001343631d
 
 RUN mkdir -p /usr/src
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lightweight WordPress container with Nginx 1.14 & PHP-FPM 7.2 based on Alpine Linux.
 
-_WordPress version currently installed:_ **4.9.8**
+_WordPress version currently installed:_ **5.0-beta2**
 
 * Used in production for my own sites, making it stable, tested and up-to-date
 * Optimized for 100 concurrent users


### PR DESCRIPTION
### What has been done
Aah, it's that lovely time of the year again. October, where I suddenly spring into life and start working on this project ;) .

This year I bumped Wordpress to 5.0-beta2 in anticipation of all that is new and shiny. However, this PR by itself is not all that great, because we don't want to update to a beta build on our production containers ofcourse.

So, in order to have support for beta WP builds for people that want to play around with it, you could push a beta branch to this fork. I will update this PR accordingly so it's waiting to be merged into your beta branch. And if you set up hub.docker.com to build a beta tag from the beta branch on github, people can both rely on latest (or a specific version) for stability or on the beta tag if they want to play around with the new stuff! 

### How to test
- Pull this branch
- Run docker-compose up --build
- See that you are now greeted with Wordpress 5.0-beta2

### Notes
(none)