### PR TITLE
Update WordPress to 5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /var/www/wp-content
 RUN chown -R nobody.nobody /var/www
 
 # WordPress
-ENV WORDPRESS_VERSION 5.1.1
-ENV WORDPRESS_SHA1 f1bff89cc360bf5ef7086594e8a9b68b4cbf2192
+ENV WORDPRESS_VERSION 5.2
+ENV WORDPRESS_SHA1 36459a4621b9e1909c606a98d08625b9e0e25bbc
 
 RUN mkdir -p /usr/src
 
@@ -32,7 +32,7 @@ RUN mkdir -p /usr/src
 RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz \
 	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
 	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
-	&& rm wordpress.tar.gz \
+	&& rm wordpress.tar.gz \    
 	&& chown -R nobody.nobody /usr/src/wordpress
 
 # Add WP CLI

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Lightweight WordPress container with Nginx 1.14 & PHP-FPM 7.2 based on Alpine Linux.
 
-_WordPress version currently installed:_ **5.1.1**
+_WordPress version currently installed:_ **5.2**
 
 * Used in production for my own sites, making it stable, tested and up-to-date
 * Optimized for 100 concurrent users


### PR DESCRIPTION
WordPress 5.2 is out 🎉 This PR will bump the installed version to 5.2.

### Notes
Wordpress 5.2 supports PHP 7.3. Do you want to wait until PHP 7.3 is available in the default apk repositories or should we find a more intrusive way to update PHP? 

Cheers! 