### PR TITLE
Update WordPress to version 5.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /var/www/wp-content
 RUN chown -R nobody.nobody /var/www
 
 # WordPress
-ENV WORDPRESS_VERSION 5.2.3
-ENV WORDPRESS_SHA1 5efd37148788f3b14b295b2a9bf48a1a467aa303
+ENV WORDPRESS_VERSION 5.2.4
+ENV WORDPRESS_SHA1 9eb002761fc8b424727d8c9d291a6ecfde0c53b7
 
 RUN mkdir -p /usr/src
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Lightweight WordPress container with Nginx 1.16 & PHP-FPM 7.3 based on Alpine Linux.
 
-_WordPress version currently installed:_ **5.2.3**
+_WordPress version currently installed:_ **5.2.4**
 
 * Used in production for my own sites, making it stable, tested and up-to-date
 * Optimized for 100 concurrent users


### PR DESCRIPTION
# What

Make sure the WordPress version is updated to the latest patch version.

More info: https://wordpress.org/support/wordpress-version/version-5-2-4/