### PR TITLE
Update WordPress to 5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /var/www/wp-content
 RUN chown -R nobody.nobody /var/www
 
 # WordPress
-ENV WORDPRESS_VERSION 5.2.4
-ENV WORDPRESS_SHA1 9eb002761fc8b424727d8c9d291a6ecfde0c53b7
+ENV WORDPRESS_VERSION 5.3
+ENV WORDPRESS_SHA1 e3edcb1131e539c2b2e10fed37f8b6683c824a98
 
 RUN mkdir -p /usr/src
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Lightweight WordPress container with Nginx 1.16 & PHP-FPM 7.3 based on Alpine Linux.
 
-_WordPress version currently installed:_ **5.2.4**
+_WordPress version currently installed:_ **5.3**
 
 * Used in production for my own sites, making it stable, tested and up-to-date
 * Optimized for 100 concurrent users


### PR DESCRIPTION
Heya 👋,

5.3 was released last Tuesday. This PR will take care of bumping the Docker image to the latest version. 
