### PR TITLE
Add php82-session and php82-tokenizer packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN apk --no-cache add \
   php82-opcache \
   php82-iconv \
   php82-pecl-imagick \
+  php82-session \
+  php82-tokenizer \
   nginx \
   supervisor \
   curl \


### PR DESCRIPTION
Some of my common wordpress plugins need these packages and I saw you're using them in https://github.com/TrafeX/docker-php-nginx/blob/master/Dockerfile as well.