### PR TITLE
Update Wordpress to 6.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ WORKDIR /var/www/wp-content
 RUN chown -R nobody.nobody /var/www
 
 # WordPress
-ENV WORDPRESS_VERSION 6.4.1
-ENV WORDPRESS_SHA1 35e62d935d6a93097366476e389752dd55d8a077
+ENV WORDPRESS_VERSION 6.4.2
+ENV WORDPRESS_SHA1 d1aedbfea77b243b09e0ab05b100b782497406dd
 
 RUN mkdir -p /usr/src
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Lightweight WordPress container with Nginx 1.24 & PHP-FPM 8.2 based on Alpine Linux.
 
-_WordPress version currently installed:_ **6.4.1**
+_WordPress version currently installed:_ **6.4.2**
 
 * Used in production for many sites, making it stable, tested and up-to-date
 * Optimized for 100 concurrent users


### PR DESCRIPTION
This PR updates the WordPress version to 6.4.2

Closes #48 