### PR TITLE
Generate salts every time the container starts, unless they're set via environment variables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,18 @@ fi
 
 # Check if wp-secrets.php is a placeholder file
 if grep -q "This is a placeholder file." /usr/src/wordpress/wp-secrets.php; then
-    echo "Generating wp-secrets.php"
-    # Generate secrets
-    curl -f https://api.wordpress.org/secret-key/1.1/salt/ >> /usr/src/wordpress/wp-secrets.php
+    # Check that secrets environment variables are not set
+    if [ ! $AUTH_KEY ] \
+    && [ ! $SECURE_AUTH_KEY ] \
+    && [ ! $LOGGED_IN_KEY ] \
+    && [ ! $NONCE_KEY ] \
+    && [ ! $AUTH_SALT ] \
+    && [ ! $SECURE_AUTH_SALT ] \
+    && [ ! $LOGGED_IN_SALT ] \
+    && [ ! $NONCE_SALT ]; then
+        echo "Generating wp-secrets.php"
+        # Generate secrets
+        curl -f https://api.wordpress.org/secret-key/1.1/salt/ >> /usr/src/wordpress/wp-secrets.php
+    fi
 fi
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,11 @@ if [ ! "$(ls -A "/var/www/wp-content" 2>/dev/null)" ]; then
     # Copy wp-content from Wordpress src to volume
     cp -r /usr/src/wordpress/wp-content /var/www/
     chown -R nobody.nobody /var/www
+fi
 
+# Check if wp-secrets.php is a placeholder file
+if grep -q "This is a placeholder file." /usr/src/wordpress/wp-secrets.php; then
+    echo "Generating wp-secrets.php"
     # Generate secrets
     curl -f https://api.wordpress.org/secret-key/1.1/salt/ >> /usr/src/wordpress/wp-secrets.php
 fi

--- a/wp-secrets.php
+++ b/wp-secrets.php
@@ -1,2 +1,5 @@
 <?php
-/** Generated file based on https://api.wordpress.org/secret-key/1.1/salt/ */
+/** This is a placeholder file. It will be replaced with a generated file
+ * based on https://api.wordpress.org/secret-key/1.1/salt/ when the container
+ * is first launched.
+ * /

--- a/wp-secrets.php
+++ b/wp-secrets.php
@@ -1,5 +1,9 @@
 <?php
 /** This is a placeholder file. It will be replaced with a generated file
  * based on https://api.wordpress.org/secret-key/1.1/salt/ when the container
- * is first launched.
- * /
+ * starts.
+ * 
+ * Alternatively, you can set the appropriate constants via environment
+ * variables. If the environment variables exist, this file will not be
+ * generated. 
+ **/


### PR DESCRIPTION
### New behavior
This pull request makes the container generate `wp-secrets.php` every time the container is recreated.

The secrets are still not persisted, so users will need to log in again each time the container is recreated. The secrets can instead be persisted by setting them in environment variables. If all the appropriate environment variables are set, the secrets will not be re-generated. This behavior is not documented in the README, though it is documented in a comment within the placeholder `wp-secrets.php` file.

### Previous behavior
Previously, when updating or recreating the container, the `wp-secrets.php` reverts to the original state without secrets defined. This is because the persistent volume is mounted to /var/www/wp-content, but the secrets are in /usr/src/wordpress/wp-secrets.php which is NOT part of the volume.

I believe this closes #42, though feedback from @bb on that matter would be appreciated. 