### PR TITLE
Make sure the wp-secrets.php file is generated once and persisted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,8 @@ RUN curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh
 COPY wp-config.php /usr/src/wordpress
 RUN chown nobody.nobody /usr/src/wordpress/wp-config.php && chmod 640 /usr/src/wordpress/wp-config.php
 
-# Append WP secrets
-COPY wp-secrets.php /usr/src/wordpress
-RUN chown nobody.nobody /usr/src/wordpress/wp-secrets.php && chmod 640 /usr/src/wordpress/wp-secrets.php
+# Link wp-secrets to location on wp-content
+RUN ln -s /var/www/wp-content/wp-secrets.php /usr/src/wordpress/wp-secrets.php
 
 # Entrypoint to copy wp-content
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,22 @@ if [ ! "$(ls -A "/var/www/wp-content" 2>/dev/null)" ]; then
     # Copy wp-content from Wordpress src to volume
     cp -r /usr/src/wordpress/wp-content /var/www/
     chown -R nobody.nobody /var/www
-
-    # Generate secrets
-    curl -f https://api.wordpress.org/secret-key/1.1/salt/ >> /usr/src/wordpress/wp-secrets.php
+fi
+# Check if wp-secrets.php exists
+if ! [ -f "/var/www/wp-content/wp-secrets.php" ]; then
+    # Check that secrets environment variables are not set
+    if [ ! $AUTH_KEY ] \
+    && [ ! $SECURE_AUTH_KEY ] \
+    && [ ! $LOGGED_IN_KEY ] \
+    && [ ! $NONCE_KEY ] \
+    && [ ! $AUTH_SALT ] \
+    && [ ! $SECURE_AUTH_SALT ] \
+    && [ ! $LOGGED_IN_SALT ] \
+    && [ ! $NONCE_SALT ]; then
+        echo "Generating wp-secrets.php"
+        # Generate secrets
+        echo '<?php' > /var/www/wp-content/wp-secrets.php
+        curl -f https://api.wordpress.org/secret-key/1.1/salt/ >> /var/www/wp-content/wp-secrets.php
+    fi
 fi
 exec "$@"

--- a/wp-secrets.php
+++ b/wp-secrets.php
@@ -1,2 +1,0 @@
-<?php
-/** Generated file based on https://api.wordpress.org/secret-key/1.1/salt/ */


### PR DESCRIPTION
I  moved the `wp-secrets.php` file to the volume mount next to wp-content to make this file persistent between container recreations. WIth a symlink I point WordPress to the right location.