### PR TITLE
Switch to docker compose v2 command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Smoke test image
         run: |-
-          docker-compose -f docker-compose.test.yml up -d wordpress
-          docker-compose -f docker-compose.test.yml run sut
+          docker compose -f docker-compose.test.yml up -d wordpress
+          docker compose -f docker-compose.test.yml run sut
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
Per deprecation notice  https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/