### PR TITLE
Add php84-pdo package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk --no-cache add \
   php84-pecl-imagick \
   php84-session \
   php84-tokenizer \
+  php84-pdo \
   nginx \
   supervisor \
   curl \


### PR DESCRIPTION
Hello, it's possible to add pdo PHP module?

Some backup plugins like [WPvivid Backup Plugin](https://wordpress.org/plugins/wpvivid-backuprestore/) are recommending php84-pdo for it for better backup performance,

`The PDO extension is not detected. Please install the extension first.`

> It is recommended to choose PDO option if pdo_mysql extension is installed on your server, which lets you backup and restore your site faster.